### PR TITLE
add conf to change status on start/stop counter

### DIFF
--- a/admin/operationorderstatus_setup.php
+++ b/admin/operationorderstatus_setup.php
@@ -128,6 +128,18 @@ $confkey = 'OPODER_STATUS_ON_PLANNED';
 $inputHtml = $form->selectarray('value'.$inputCount, $TstatusAvailable, $conf->global->{$confkey}, 0, 0, 0, '', 0, 0, 0, '', '', 1);
 _printFormPart($confkey, $inputHtml);
 
+_printOnOff('OPORDER_CHANGE_OR_STATUS_ON_START');
+
+$confkey = 'OPODER_STATUS_ON_START';
+$inputHtml = $form->selectarray('value'.$inputCount, $TstatusAvailable, $conf->global->{$confkey}, 0, 0, 0, '', 0, 0, 0, '', '', 1);
+_printFormPart($confkey, $inputHtml, false, "", $confkey."_help");
+
+_printOnOff('OPORDER_CHANGE_OR_STATUS_ON_STOP');
+
+$confkey = 'OPODER_STATUS_ON_STOP';
+$inputHtml = $form->selectarray('value'.$inputCount, $TstatusAvailable, $conf->global->{$confkey}, 0, 0, 0, '', 0, 0, 0, '', '', 1);
+_printFormPart($confkey, $inputHtml, false, "", $confkey."_help");
+
 
 
 print '</table>';

--- a/class/operationordertasktime.class.php
+++ b/class/operationordertasktime.class.php
@@ -128,4 +128,28 @@ class OperationOrderTaskTime extends SeedObject
 		else return -1;
 	}
 
+	/**
+	 * function pour vérifier si d'autres compteurs sont en cours
+	 * => on ne change pas le statut d'un OR s'il y a encore quelqu'un qui travaille dessus
+	 *
+	 * @param int $ordet_id l'id d'une ligne de l'OR à vérifier
+	 *
+	 * @return int
+	 */
+	public function remainingCountersForOR($ordet_id)
+	{
+		$sql = "SELECT COUNT(c.rowid) as nb";
+		$sql.= " FROM ".MAIN_DB_PREFIX."operationordertasktime c";
+		$sql.= " LEFT JOIN ".MAIN_DB_PREFIX."operationorderdet ood ON ood.rowid = c.fk_orDet";
+		$sql.= " WHERE c.task_datehour_f IS NULL AND c.fk_orDet =".$ordet_id;
+
+		$resql = $this->db->query($sql);
+		if ($resql)
+		{
+			$obj = $this->db->fetch_object($resql);
+			return (int) $obj->nb;
+		}
+		else return -1;
+	}
+
 }

--- a/js/manager.js.php
+++ b/js/manager.js.php
@@ -392,7 +392,7 @@ class Application
 				let msgDiv = $('#responseMessageSuccess');
 				msgDiv.html(response.msg);
 				msgDiv.fadeIn();
-				msgDiv.fadeOut(1500);
+				msgDiv.fadeOut(3000);
 			}
 			else if (response.result == 0 && response.errorMsg)
 			{
@@ -426,7 +426,7 @@ class Application
 					let msgDiv = $('#responseMessageSuccess');
 					msgDiv.html(response.msg);
 					msgDiv.fadeIn();
-					msgDiv.fadeOut(1500);
+					msgDiv.fadeOut(3000);
 				}
 				else if (response.result == 0 && response.errorMsg)
 				{
@@ -465,7 +465,7 @@ class Application
 					let msgDiv = $('#responseMessageSuccess');
 					msgDiv.html(response.msg);
 					msgDiv.fadeIn();
-					msgDiv.fadeOut(1500);
+					msgDiv.fadeOut(3000);
 				}
 				else if (response.result == 0 && response.errorMsg)
 				{
@@ -489,7 +489,7 @@ class Application
 					let msgDiv = $('#responseMessageSuccess');
 					msgDiv.html(response.msg);
 					msgDiv.fadeIn();
-					msgDiv.fadeOut(1500);
+					msgDiv.fadeOut(3000);
 				}
 				else if (response.result == 0 && response.errorMsg)
 				{
@@ -500,7 +500,5 @@ class Application
 
 		this.resetState();
 	}
-
-	// trouver un moyen d'afficher l'alerte dans le dom quelque part => done
 
 }

--- a/langs/fr_FR/operationorder.lang
+++ b/langs/fr_FR/operationorder.lang
@@ -30,6 +30,12 @@ BarCodeImpSetup=Paramétrage code-barres des tâches improductives
 BarCodeAdded=Code-barres ajouté
 BarCodeDeleted=Code-barres supprimé
 AddBarCode=Ajouter un code-barres
+OPORDER_CHANGE_OR_STATUS_ON_START=Au démarrage d'une tâche, changer le statut de l'ordre de réparation associé
+OPODER_STATUS_ON_START=Statut à utiliser lors de la réalisation de tâches sur l'OR
+OPODER_STATUS_ON_START_help=Attention ce statut doit être accessible par le statut précédent de l'OR<br />ex.: statut précédent "planifié" => statut à utiliser "en cours à l'atelier"
+OPORDER_CHANGE_OR_STATUS_ON_STOP=A l'arrêt d'une tâche, changer le statut de l'ordre de réparation associé (si aucune autre tâche n'est en court)
+OPODER_STATUS_ON_STOP=Statut à utiliser lors de l'arrêt de tâches sur l'OR
+OPODER_STATUS_ON_STOP_help=Attention ce statut doit être accessible par le statut précédent de l'OR<br />ex.: statut précédent "en cours à l'atelier" => statut à utiliser "planifié"
 
 # MENU
 LeftMenuOperationOrder=Ordre de réparation
@@ -43,7 +49,7 @@ LeftMenuOperationOrderStatusList=Liste
 OperationOrderInfo=Suivi
 LeftMenuOperationOrderManager=Atelier
 
-# EVEN ACTION COM CONF
+# EVENT ACTION COM CONF
 OperationOrderStatusChange=Changement de status d'un ordre de réparation
 OperationOrderStatusChangeDesc=permet l'historisation des changements de status des ordres de réparation
 

--- a/scripts/managerinterface.php
+++ b/scripts/managerinterface.php
@@ -470,6 +470,8 @@ if (empty($reshook) && !empty($action))
 				$data['debug'].= 'stop counter '.$counter->label.' '.$counter->id;
 			}
 
+			$remaining = $counter->remainingCountersForOR($line->id);
+
 			$newCounter = new OperationOrderTaskTime($db);
 			$newCounter->label = $line->label;
 			$newCounter->task_datehour_d = dol_now();
@@ -481,12 +483,11 @@ if (empty($reshook) && !empty($action))
 			if ($retSave > 0)
 			{
 				// s'il y a déjà des compteurs en court sur l'OR, on a déjà changé le statut
-				$remaining = $counter->remainingCountersForOR($line->id);
-
 				// changement de statut de l'OR de la ligne
 				if (!empty($conf->global->OPORDER_CHANGE_OR_STATUS_ON_START) && !empty($conf->global->OPODER_STATUS_ON_START) && !$remaining)
 				{
 					list($changeReturn, $message) = changeORStatus($line->fk_operation_order, $conf->global->OPODER_STATUS_ON_START);
+					$data['debug'] = $changeReturn . ' | ' . $message;
 					if ($changeReturn) $data['msg'].=$message;
 					else $data['errorMsg'].=$message;
 				}

--- a/scripts/managerinterface.php
+++ b/scripts/managerinterface.php
@@ -192,7 +192,7 @@ if (empty($reshook) && !empty($action))
 
 		if (!empty($OR->lines))
 		{
-			$TPointable = $ProdErrors = array();
+			$TPointable = $ProdErrors = $TLastLines = array();
 
 			$alreadyUsed = array();
 			$sql = "SELECT mvt.fk_product, SUM(mvt.value) as total FROM ".MAIN_DB_PREFIX."stock_mouvement as mvt";
@@ -308,6 +308,15 @@ if (empty($reshook) && !empty($action))
 
 				$ordet->time_spent += $counter->task_duration;
 				$ordet->update($usr);
+
+				$remaining = $counter->remainingCountersForOR($ordet->id);
+				// changement de statut de l'OR de la ligne
+				if (!empty($conf->global->OPORDER_CHANGE_OR_STATUS_ON_STOP) && !empty($conf->global->OPODER_STATUS_ON_STOP) && !$remaining)
+				{
+					list($changeReturn, $message) = changeORStatus($ordet->fk_operation_order, $conf->global->OPODER_STATUS_ON_STOP);
+					if ($changeReturn) $data['msg'].=$message;
+					else $data['errorMsg'].=$message;
+				}
 			}
 //			$data['debug'].= 'stop counter '.$counter->label.' '.$counter->id;
 		}
@@ -335,7 +344,7 @@ if (empty($reshook) && !empty($action))
 		if ($retSave > 0)
 		{
 //			$data['debug'].= 'start counter '.$newCounter->label.' '.$newCounter->id;
-			$data['msg'] = $langs->trans('MsgCounterStart', $label, $usr->login);;
+			$data['msg'].= $langs->trans('MsgCounterStart', $label, $usr->login);
 			$data['result'] = 1;
 		}
 		else
@@ -372,8 +381,17 @@ if (empty($reshook) && !empty($action))
 
 					$ordet->time_spent += $counter->task_duration;
 					$ordet->update($usr);
+
+					$remaining = $counter->remainingCountersForOR($ordet->id);
+					// changement de statut de l'OR de la ligne
+					if (!empty($conf->global->OPORDER_CHANGE_OR_STATUS_ON_STOP) && !empty($conf->global->OPODER_STATUS_ON_STOP) && !$remaining)
+					{
+						list($changeReturn, $message) = changeORStatus($ordet->fk_operation_order, $conf->global->OPODER_STATUS_ON_STOP);
+						if ($changeReturn) $data['msg'].=$message;
+						else $data['errorMsg'].=$message;
+					}
 				}
-				$data['msg'] = $langs->trans('MsgCounterStop', $counter->label, $usr->login);
+				$data['msg'].= $langs->trans('MsgCounterStop', $counter->label, $usr->login);
 				$data['result'] = 1;
 			}
 			else
@@ -382,7 +400,7 @@ if (empty($reshook) && !empty($action))
 			}
 		}
 		else if ($ret == 0) {
-			$data['msg'] = $langs->trans('noCounterToStop');
+			$data['msg'].= $langs->trans('noCounterToStop');
 			$data['result'] = 1;
 		}
 		else
@@ -438,6 +456,15 @@ if (empty($reshook) && !empty($action))
 
 					$ordet->time_spent += $counter->task_duration;
 					$ordet->update($usr);
+
+					$remaining = $counter->remainingCountersForOR($ordet->id);
+					// changement de statut de l'OR de la ligne
+					if (!empty($conf->global->OPORDER_CHANGE_OR_STATUS_ON_STOP) && !empty($conf->global->OPODER_STATUS_ON_STOP) && !$remaining)
+					{
+						list($changeReturn, $message) = changeORStatus($ordet->fk_operation_order, $conf->global->OPODER_STATUS_ON_STOP);
+						if ($changeReturn) $data['msg'].=$message;
+						else $data['errorMsg'].=$message;
+					}
 				}
 
 				$data['debug'].= 'stop counter '.$counter->label.' '.$counter->id;
@@ -453,8 +480,19 @@ if (empty($reshook) && !empty($action))
 			$retSave = $newCounter->save($usr);
 			if ($retSave > 0)
 			{
+				// s'il y a déjà des compteurs en court sur l'OR, on a déjà changé le statut
+				$remaining = $counter->remainingCountersForOR($line->id);
+
+				// changement de statut de l'OR de la ligne
+				if (!empty($conf->global->OPORDER_CHANGE_OR_STATUS_ON_START) && !empty($conf->global->OPODER_STATUS_ON_START) && !$remaining)
+				{
+					list($changeReturn, $message) = changeORStatus($line->fk_operation_order, $conf->global->OPODER_STATUS_ON_START);
+					if ($changeReturn) $data['msg'].=$message;
+					else $data['errorMsg'].=$message;
+				}
+
 				$data['debug'].= 'start counter '.$newCounter->label.' '.$newCounter->id;
-				$data['msg'] = $langs->trans('MsgCounterStart', $counter->label, $usr->login);
+				$data['msg'].= $langs->trans('MsgCounterStart', $newCounter->label, $usr->login);
 				$data['result'] = 1;
 			}
 		}
@@ -622,4 +660,29 @@ function displayBarcode($code = '')
 	$barcode =  '<img src="'.$url.'" title="'.$code.'" border="0">';
 
 	return $barcode;
+}
+
+function changeORStatus($or_id, $fk_status)
+{
+	global $user, $db, $langs;
+
+	$return = false;
+	$message = "";
+
+	$OR = new OperationOrder($db);
+	$OR->fetch($or_id);
+
+	$ret = $OR->setStatus($user, $fk_status);
+	if ($ret > 0)
+	{
+		$OR->loadStatusObj();
+		$message.= $langs->trans('OperationOrderSetStatus', $OR->objStatus->label, $OR->ref).'<br />';
+		$return = true;
+	}
+	else
+	{
+		$message.=$OR->error.'<br />';
+	}
+
+	return array($return, $message);
 }


### PR DESCRIPTION
Ajout de deux conf pour activer le changement de statut au start et au stop d'un compteur OR lié à une ligne.
Ajout de deux conf pour sélectionner les statuts à utiliser dans ces deux cas.

Ajout de méthode sur les compteurs pour vérifier combien de compteurs sont en court sur un OR.