### PR TITLE
Fix develop second round

### DIFF
--- a/lib/operationorder.lib.php
+++ b/lib/operationorder.lib.php
@@ -1574,7 +1574,24 @@ function calculatePlannedTimeEventByBusinessHours($startTime, $endTime){
             $endTimeDateFormat = new DateTime();
             $endTimeDateFormat->setTimestamp($endTime);
 
-            $timeSchedule = $dateDSchedule->diff($endTimeDateFormat);
+
+            //si la date de fin est placée hors créneau
+            if($endTime < $dateDScheduleTimeStamp) {
+
+                $TPrevScheduleF = explode(':', $TNextSchedules[$i-1]['max']);
+                $prevDateFScheduleTimeStamp = $TNextSchedules[$i-1]['date'] + convertTime2Seconds($TPrevScheduleF[0], $TPrevScheduleF[1]);
+                $prevDateFSchedule = new DateTime();
+                $prevDateFSchedule->setTimestamp($prevDateFScheduleTimeStamp);
+
+                $timeSchedule = $prevDateFSchedule->diff($endTimeDateFormat);
+
+            }
+            //si la date de fin est placée sur un créneau
+            else
+            {
+                $timeSchedule = $dateDSchedule->diff($endTimeDateFormat);
+            }
+
         }
 
         //convertis temps du créneau en secondes

--- a/lib/operationorder.lib.php
+++ b/lib/operationorder.lib.php
@@ -1612,7 +1612,7 @@ function calculatePlannedTimeEventByBusinessHours($startTime, $endTime){
  * @param timestamp $endTime
  * @return boolean
  */
-function verifyScheduleInBusinessHours($startTime, $endTime){
+function verifyScheduleInBusinessHours($startTime){
 
     $TWeekDates = getWeekRange($startTime);     //dates de la semaine en cours
     $beginOfWeek = $TWeekDates[0];              //début de la semaine
@@ -1627,7 +1627,7 @@ function verifyScheduleInBusinessHours($startTime, $endTime){
             $TScheduleMin = explode(':', $schedule['min']);
             $TScheduleMax = explode(':', $schedule['max']);
 
-            if($startTime >= ($date + convertTime2Seconds($TScheduleMin[0], $TScheduleMin[1])) && $endTime <= ($date + convertTime2Seconds($TScheduleMax[0], $TScheduleMax[1]))){
+            if($startTime >= ($date + convertTime2Seconds($TScheduleMin[0], $TScheduleMin[1])) && $startTime <= ($date + convertTime2Seconds($TScheduleMax[0], $TScheduleMax[1]))){
                 return true;
             }
 

--- a/operationorder_planning.php
+++ b/operationorder_planning.php
@@ -350,7 +350,7 @@ $Tfullcalendar_scheduler_businessHours_days = array('1'=>'lundi', '2'=>'mardi', 
                                 $.each(dayCurrent, function (index, value) {
 
                                     result.push({
-                                            daysOfWeek: [<?php print $key ?>],
+                                        daysOfWeek: [<?php print $key ?>],
                                         startTime: value['min'],
                                         endTime: value['max'],
                                     });
@@ -362,8 +362,8 @@ $Tfullcalendar_scheduler_businessHours_days = array('1'=>'lundi', '2'=>'mardi', 
                         } else {
                             result.push({
                                 daysOfWeek: [1,2,3,4,5],
-                                startTime: fullcalendar_scheduler_businessHours_weekend_start,
-                                endTime: fullcalendar_scheduler_businessHours_week_end,
+                                startTime: '<?php print $conf->global->FULLCALENDARSCHEDULER_BUSINESSHOURS_WEEK_START ?>',
+                                endTime: '<?php print $conf->global->FULLCALENDARSCHEDULER_BUSINESSHOURS_WEEK_END ?>',
                             });
                         }
 

--- a/operationorder_planning.php
+++ b/operationorder_planning.php
@@ -250,6 +250,7 @@ $Tfullcalendar_scheduler_businessHours_days = array('1'=>'lundi', '2'=>'mardi', 
                 },
                 eventResizeStop: function(info) {
 				    $('.operationOrderTooltip').hide();
+                    calendar.refetchEvents();
                 },
                 eventDrop: function(eventDropInfo) {
 				    if(!eventDropInfo.event.allDay)

--- a/operationorder_planning.php
+++ b/operationorder_planning.php
@@ -273,10 +273,9 @@ $Tfullcalendar_scheduler_businessHours_days = array('1'=>'lundi', '2'=>'mardi', 
                             dataType: 'json',
                             // La fonction à apeller si la requête aboutie
                             success: function (data) {
-                                calendar.refetchEvents();
                             }
                         });
-                    } else calendar.refetchEvents();
+                    }
 
                     calendar.refetchEvents();
 
@@ -362,11 +361,15 @@ $Tfullcalendar_scheduler_businessHours_days = array('1'=>'lundi', '2'=>'mardi', 
                             <?php } ?>
 
                         } else {
+
+                            <?php if(!empty($conf->global->FULLCALENDARSCHEDULER_BUSINESSHOURS_WEEK_START) && !empty($conf->global->FULLCALENDARSCHEDULER_BUSINESSHOURS_WEEK_END)) {?>
                             result.push({
                                 daysOfWeek: [1,2,3,4,5],
                                 startTime: '<?php print $conf->global->FULLCALENDARSCHEDULER_BUSINESSHOURS_WEEK_START ?>',
                                 endTime: '<?php print $conf->global->FULLCALENDARSCHEDULER_BUSINESSHOURS_WEEK_END ?>',
                             });
+
+                            <?php } ?>
                         }
 
                         calendar.setOption('businessHours', result);

--- a/operationorder_planning.php
+++ b/operationorder_planning.php
@@ -278,6 +278,8 @@ $Tfullcalendar_scheduler_businessHours_days = array('1'=>'lundi', '2'=>'mardi', 
                         });
                     } else calendar.refetchEvents();
 
+                    calendar.refetchEvents();
+
                 }
             });
 

--- a/scripts/interface.php
+++ b/scripts/interface.php
@@ -278,6 +278,8 @@ function _updateOperationOrderAction($startTime, $endTime, $fk_action, $action, 
 
     $error = 0;
 
+    if($allDay) return 1;
+
     if($action == 'drop')
     {
         //si la date de début de l'événement est hors créneau, on ne fait rien

--- a/scripts/interface.php
+++ b/scripts/interface.php
@@ -281,12 +281,17 @@ function _updateOperationOrderAction($startTime, $endTime, $fk_action, $action, 
         $db->begin();
         $action_or = new OperationOrderAction($db);
         $res = $action_or->fetch($fk_action);
-        $canDrop = verifyScheduleInBusinessHours($startTime, $endTime);
 
-        if ($res > 0 && $canDrop)
+        $operationorder = new OperationOrder($db);
+        $res = $operationorder->fetch($action_or->fk_operationorder);
+
+        $time_planned = calculatePlannedTimeEventByBusinessHours($startTime, $endTime);
+
+        if ($res > 0)
         {
             $action_or->dated = $startTime;
-            $action_or->datef = $endTime;
+//            $action_or->datef = $endTime;
+            $operationorder->time_planned_f = $time_planned;
             if (!empty($allDay)) $action_or->fullday = 1;
             $res = $action_or->save($user);
             if ($res > 0)


### PR DESCRIPTION
Il est maintenant possible de : 
- Resize  en plaçant la fin de l'événement sur une zone hors créneau
- Drop sur une zone hors créneau tant que la date de début est dans un créneau

==> tout est recalculé (temps plannifié + date de fin)