### PR TITLE
T1802 - New dict check negative value

### DIFF
--- a/class/operationorder.class.php
+++ b/class/operationorder.class.php
@@ -478,7 +478,7 @@ class OperationOrder extends SeedObject
 	    }
 	    else $ok = true;
 
-		if(!$ok) setEventMessage($langs->trans());
+		if(!$ok) setEventMessage($langs->trans('MissingNegativeProductVentilationLine'), 'warnings');
 
     	return $ok;
 	}

--- a/core/modules/modOperationOrder.class.php
+++ b/core/modules/modOperationOrder.class.php
@@ -165,19 +165,19 @@ class modOperationOrder extends DolibarrModules
                 'OperationOrderDictTypeLabel'
             ),                                                    // Label of tables
             'tabsql' => array(
-                'SELECT f.rowid, f.code, f.label, f.position, f.active, f.entity FROM '.MAIN_DB_PREFIX.'c_operationorder_type as f WHERE f.entity IN (0, '.$conf->entity.')'
+                'SELECT f.rowid, f.code, f.label, f.blocked_status_code, f.position, f.active, f.entity FROM '.MAIN_DB_PREFIX.'c_operationorder_type as f WHERE f.entity IN (0, '.$conf->entity.')'
             ),
             'tabsqlsort' => array(
                 'position ASC, label ASC'
             ),
             'tabfield' => array(
-                'code,label,position'
+                'code,label,blocked_status_code,position'
             ),
             'tabfieldvalue' => array(
-                'code,label,position,entity'
+                'code,label,blocked_status_code,position,entity'
             ),
             'tabfieldinsert' => array(
-                'code,label,position,entity'
+                'code,label,blocked_status_code,position,entity'
             ),
             'tabrowid' => array(
                 'rowid'

--- a/langs/fr_FR/operationorder.lang
+++ b/langs/fr_FR/operationorder.lang
@@ -12,6 +12,7 @@ LinkToThirparty=Lien vers le tiers
 
 OperationOrderDictTypeLabel=Type d'ordre de réparation
 Blocked_status_code=Statut inaccessible si aucune ligne "ventilation produit" négative n'est présente
+MissingNegativeProductVentilationLine=Ligne "Ventilation produit" négative manquante
 
 # SETUP
 ParamLabel=Nom du paramètre

--- a/langs/fr_FR/operationorder.lang
+++ b/langs/fr_FR/operationorder.lang
@@ -11,6 +11,7 @@ AbricotNeedUpdate=Le module abricot doit être mis à jour
 LinkToThirparty=Lien vers le tiers
 
 OperationOrderDictTypeLabel=Type d'ordre de réparation
+Blocked_status_code=Statut inaccessible si aucune ligne "ventilation produit" négative n'est présente
 
 # SETUP
 ParamLabel=Nom du paramètre

--- a/operationorder_card.php
+++ b/operationorder_card.php
@@ -1219,7 +1219,8 @@ else
 							$statusAllowed = new OperationOrderStatus($db);
 							$res = $statusAllowed->fetch($fk_status);
 							if($res>0){
-								print dolGetButtonAction($statusAllowed->label, '', 'default', $actionUrl . 'setStatus&fk_status='.$fk_status, '', $statusAllowed->userCan($user, 'changeToThisStatus'));
+								$userCan = $object->checkNegativeProductVentilation($statusAllowed->code) ? $statusAllowed->userCan($user, 'changeToThisStatus') : false;
+								print dolGetButtonAction($statusAllowed->label, '', 'default', $actionUrl . 'setStatus&fk_status='.$fk_status, '', $userCan);
 							}
 						}
 					}


### PR DESCRIPTION
Sur le dictionnaire Dictionnaires - Type d'ordre de réparation Ajouter la Colonne "Status de l'OR bloquant si produit Ventillation négatif non existeant)
 Par exemple sur toute les lignes de ce dictionnaire sauf "Contrat interne", on met le code CLOSED (qui correspond au satus des OR cloturé) Il ne sera pas possible de passé au statut CLOSED un OR (sauf contrat interne) si il n'y a pas dedans une ligne avec un HT négatif d'un produit/service qui l'attribut complémentaire "Ventialtion produit" non vide