### PR TITLE
T1781 - Créer evtOR depuis operationOrder card 

### DIFF
--- a/class/operationorderstatus.class.php
+++ b/class/operationorderstatus.class.php
@@ -218,6 +218,7 @@ class OperationOrderStatus extends SeedObject
 			'default'=>0,
 			'visible'=> -1,
 			'position'=>110,
+			'required'=>0,
 		)
 	);
 

--- a/class/operationorderstatus.class.php
+++ b/class/operationorderstatus.class.php
@@ -211,6 +211,14 @@ class OperationOrderStatus extends SeedObject
 			'notnull'=>1,
 			'visible'=>0,
 		),
+		'require_planned_date' => array(
+			'type'=>'boolean',
+			'label'=>'RequirePlannedDate',
+			'enabled'=>1,
+			'default'=>0,
+			'visible'=> -1,
+			'position'=>110,
+		)
 	);
 
 	public $code;

--- a/langs/fr_FR/operationorder.lang
+++ b/langs/fr_FR/operationorder.lang
@@ -325,3 +325,4 @@ ClotureEventOnThisStatus=Lorsqu'un ordre de réparation passe sur ce statut, le 
 
 RequirePlannedDate =Seuls les OR possédant une date de plannification peuvent passer à ce statut
 PlannedDateMustBeFilledToPassAtThisStatus =La date de planification doit être renseignée pour passer à ce statut
+OverloadReachedForThisDay =La surcharge est atteinte pour ce jour 

--- a/langs/fr_FR/operationorder.lang
+++ b/langs/fr_FR/operationorder.lang
@@ -322,3 +322,6 @@ LeftMenuOperationOrderORPlanning=Activités journalières
 
 ErrorNoUserInGroupOrNoGroup=Pas d'utilisateur dans le "Groupe d'utilisateurs à prendre en compte pour le planning OR" ou pas de groupe configuré
 ClotureEventOnThisStatus=Lorsqu'un ordre de réparation passe sur ce statut, le champ date de clôture est peuplé
+
+RequirePlannedDate =Seuls les OR possédant une date de plannification peuvent passer à ce statut
+PlannedDateMustBeFilledToPassAtThisStatus =La date de planification doit être renseignée pour passer à ce statut

--- a/lib/operationorder.lib.php
+++ b/lib/operationorder.lib.php
@@ -1971,6 +1971,26 @@ function getTimeAvailableByDateByUsersCapacity($date_timestamp, $forWeek=false)
 
 }
 
+
+function isJourFull($date){
+	global $conf;
+
+	$isfull = false;
+
+	$res_TimePlanned = getTimePlannedByDate($date);
+	//temps plannifié par date
+	$res_TimeUserCapacity = getTimeAvailableByDateByUsersCapacity($date);    //temps disponible en fonction de la capacité de chaque utilisateur
+	//on calcule le pourcentage de temps plannifié par rapport au temps disponible
+	$percentage = 0;
+	if(!empty($res_TimeUserCapacity))
+	{
+		$percentage = ($res_TimePlanned * 100) / $res_TimeUserCapacity;
+		if($percentage >= $conf->global->OPERATION_ORDER_PERCENTAGECAPACITY_ALERTPLANNINGOR) $isfull = true;
+	}
+	return $isfull;
+}
+
+
 function daysAvailableBetween($dated, $datef){
 
 

--- a/operationorder_card.php
+++ b/operationorder_card.php
@@ -135,6 +135,14 @@ if (empty($reshook))
                 } elseif ($attribute == 'planned_date')
                 {
                     $object->planned_date = dol_mktime(GETPOST('planned_datehour'), GETPOST('planned_datemin'), 0, GETPOST('planned_datemonth'), GETPOST('planned_dateday'), GETPOST('planned_dateyear'));
+					$date = new DateTime();
+					$date->setTimestamp($object->planned_date);
+					$date->setTime(0,0,0);
+					$date = $date->getTimestamp();
+                    if (isJourFull($date)){
+               			setEventMessage('OverloadReachedForThisDay', 'errors');
+					}
+//                    var_dump(isJourFull($date));exit();
                 }
                 else
                 {
@@ -914,7 +922,7 @@ else
 
 			}
 
-            // Contrat
+			// Contrat
             if (!empty($conf->contrat->enabled))
             {
                 $langs->load("contrat");

--- a/operationorder_card.php
+++ b/operationorder_card.php
@@ -888,9 +888,22 @@ else
                     }
                 }
             }
-//Création de l'OR en vue planning si statut = Planned
-            $plannedStatus = array(6,196,197,198,199);
-			if(in_array($object->status,$plannedStatus)){
+
+//Create ORaction if status = planned
+			//To collect each rowid where require_planned_date=1
+			$sqlIDStatusPlanned = 'SELECT rowid';
+			$sqlIDStatusPlanned .= ' FROM '.MAIN_DB_PREFIX. 'operationorder_status';
+			$sqlIDStatusPlanned .= ' WHERE require_planned_date=1';
+			$resqlIDStatusPlanned = $db->query($sqlIDStatusPlanned);
+			$cpt = 0;
+			while ($cpt < $resqlIDStatusPlanned->num_rows){
+				//To fill the array
+				$plannedRowId =$db->fetch_object($resqlIDStatusPlanned);
+				$IDStatusPlanned[] = $plannedRowId->rowid;
+				$cpt+=1;
+			}
+			//If status = planned
+			if(in_array($object->status,$IDStatusPlanned)){
 				if (!empty($object->planned_date)){
 					$endTime = '';
 					$allDay = '';
@@ -899,6 +912,7 @@ else
 					createOperationOrderAction($planned_date,$endTime,$allDay, $id_operationorder);
 				}
 
+			}
 
             // Contrat
             if (!empty($conf->contrat->enabled))


### PR DESCRIPTION
Création de l'eventOR dans le calendrier "planification" lors du passage au statut "planifié"

- **Modification permissions statut** : possible de passer au statut "planifié depuis "brouillon" et "validé"
- **Ajout champs statut : "require_planned_date"** -> ne permet pas passage au statut "Planifié" pour ORs sans date de planification
- **Création evtOR** si statut = "planifié" et champs "date de planification" rempli
- **Creation fonction dans lib : isJourFull** -> test si surcharge est atteinte sur  jour saisie dans date de planif  
- Test surcharge sur update du champ "date de planification" + alerte si surcharge 
- Traductions