### PR TITLE
FIX : marque page OR ne fonctionnait pas en préprod

### DIFF
--- a/list.php
+++ b/list.php
@@ -393,8 +393,8 @@ if (!empty($_POST)){
 ?>
 <script>
 	// var url =
-	let url = '/client/theobald/dolibarr/htdocs/bookmarks/card.php?action=create&url='
-	url+="<?php	echo urlencode($_SERVER['PHP_SELF'].'?'.implode("&",$addUrl)); ?>"
+	let url = '<?php echo DOL_URL_ROOT?>/bookmarks/card.php?action=create&url='
+	url+="<?php echo urlencode($_SERVER['PHP_SELF'].'?'.implode("&",$addUrl)); ?>"
 	$('#boxbookmark option[value="newbookmark"]').attr('rel', url);
 	console.log(url)
 </script>


### PR DESCRIPTION
Le début de L’URL menant à la page des bookmarks était codé en dur et correspondait à mon environnement local : 

- Remplacement de L’URL brute par **DOL_URL_ROOT** (dynamique)