### PR TITLE
FIX : Date planification OR + Vue planning 

### DIFF
--- a/langs/fr_FR/operationorder.lang
+++ b/langs/fr_FR/operationorder.lang
@@ -326,4 +326,5 @@ ClotureEventOnThisStatus=Lorsqu'un ordre de réparation passe sur ce statut, le 
 RequirePlannedDate =Seuls les OR possédant une date de plannification peuvent passer à ce statut
 PlannedDateMustBeFilledToPassAtThisStatus=Merci de saisir une date de plannification
 OverloadReachedForThisDay =La surcharge est atteinte pour ce jour
-OperationOrderActionNotCreated =LA vue planning de l'OR ne s'est pas correctement crée
+OperationOrderActionNotCreated =La vue planning de l'OR ne s'est pas correctement crée
+OpActionCantBeCreatedBecauseOfPlannedDate=La vue planning de cet OR ne peut pas être crée car la date de planification est vide

--- a/langs/fr_FR/operationorder.lang
+++ b/langs/fr_FR/operationorder.lang
@@ -324,6 +324,6 @@ ErrorNoUserInGroupOrNoGroup=Pas d'utilisateur dans le "Groupe d'utilisateurs à 
 ClotureEventOnThisStatus=Lorsqu'un ordre de réparation passe sur ce statut, le champ date de clôture est peuplé
 
 RequirePlannedDate =Seuls les OR possédant une date de plannification peuvent passer à ce statut
-PlannedDateMustBeFilledToPassAtThisStatus =La date de planification doit être renseignée pour passer à ce statut
+PlannedDateMustBeFilledToPassAtThisStatus=Merci de saisir une date de plannification
 OverloadReachedForThisDay =La surcharge est atteinte pour ce jour
 OperationOrderActionNotCreated =LA vue planning de l'OR ne s'est pas correctement crée

--- a/lib/operationorder.lib.php
+++ b/lib/operationorder.lib.php
@@ -936,7 +936,7 @@ function getTHoraire()
  * @param int $id_operationorder
  * @return  int         1 if OK, -1 if KO
  */
-function createOperationOrderAction($startTime, $endTime, $allDay, $id_operationorder){
+function createOperationOrderAction($startTime, $endTime, $allDay, $id_operationorder, $setstatus = false){
 
     global $langs, $db, $user, $conf;
 
@@ -972,18 +972,22 @@ function createOperationOrderAction($startTime, $endTime, $allDay, $id_operation
             if(empty($operationorder->array_options)) $operationorder->fetch_optionals();
             $operationorder->planned_date = intval($action_or->dated);
             $operationorder->save($user);
-            $fk_status = $conf->global->OPODER_STATUS_ON_PLANNED;
+            if ($setstatus == true)
+			{
+				$fk_status = $conf->global->OPODER_STATUS_ON_PLANNED;
 
-            $statusAllowed = new OperationOrderStatus($db);
-            $res = $statusAllowed->fetch($fk_status);
-            if ($res > 0 && $statusAllowed->userCan($user, 'changeToThisStatus'))
-            {
-                $res = $operationorder->setStatus($user, $fk_status);
+				$statusAllowed = new OperationOrderStatus($db);
+				$res = $statusAllowed->fetch($fk_status);
+				if ($res > 0 && $statusAllowed->userCan($user, 'changeToThisStatus'))
+				{
+					$res = $operationorder->setStatus($user, $fk_status);
 
-                if($res < 0) $error++;
-            } else {
-                $error++;
-            }
+					if($res < 0) $error++;
+				} else {
+					$error++;
+				}
+			}
+
         }
         else
         {

--- a/operationorder_card.php
+++ b/operationorder_card.php
@@ -242,7 +242,7 @@ if (empty($reshook))
 						} else{
 							dol_print_error($this->db);
 						}
-						if($obj->required_planned_date == 1 && empty($object->planned_date)){
+						if($obj->require_planned_date == 1 && empty($object->planned_date)){
 							setEventMessage($langs->trans('PlannedDateMustBeFilledToPassAtThisStatus'), 'errors');
 							break;
 						}

--- a/operationorder_card.php
+++ b/operationorder_card.php
@@ -901,7 +901,7 @@ else
 			//To collect each rowid where require_planned_date=1
 			$sql = 'SELECT rowid';
 			$sql .= ' FROM '.MAIN_DB_PREFIX.'operationorder_status';
-			$sql .= ' WHERE require_planned_date=1';
+			$sql .= ' WHERE display_on_planning=1';
 			$resql = $db->query($sql);
 			if ($resql){
 				$cpt = 0;
@@ -922,6 +922,8 @@ else
 						if ($res<0){
 							setEventMessage('OperationOrderActionNotCreated', 'errors');
 						}
+					} else {
+						setEventMessage('OpActionCantBeCreatedBecauseOfPlannedDate', 'warnings');
 					}
 				}
 			} else {

--- a/operationorder_planning.php
+++ b/operationorder_planning.php
@@ -64,7 +64,7 @@ if($action == "createOperationOrderAction"){
 
     global $langs;
 
-    $res = createOperationOrderAction($startTime, $endTime,$allDay, $id_operationorder);
+    $res = createOperationOrderAction($startTime, $endTime,$allDay, $id_operationorder, true);
 
     if($res < 0){
         setEventMessage($langs->trans('ErrorORActionCreation'), 'errors');

--- a/operationorderstatus_card.php
+++ b/operationorderstatus_card.php
@@ -115,6 +115,7 @@ if (empty($reshook))
 			$object->clean_event = GETPOST('clean_event', 'int'); // Lorsque la checkbox est décochée, le $_REQUEST ne contient pas l'élément ce qui fait la value n'est pas setté
 			$object->save_date_cloture = GETPOST('save_date_cloture', 'int'); // Lorsque la checkbox est décochée, le $_REQUEST ne contient pas l'élément ce qui fait la value n'est pas setté
 			$object->planable = GETPOST('planable', 'int'); // Lorsque la checkbox est décochée, le $_REQUEST ne contient pas l'élément ce qui fait la value n'est pas setté
+			$object->require_planned_date = GETPOST('require_planned_date', 'int'); // Lorsque la checkbox est décochée, le $_REQUEST ne contient pas l'élément ce qui fait la value n'est pas setté
 
 
 			$object->TGroupCan = $TGroupCan;
@@ -187,7 +188,6 @@ if (empty($reshook))
 
 			header('Location: '.dol_buildpath('/operationorder/operationorderstatus_card.php', 1).'?id='.$object->id);
 			exit;
-
 		case 'modif':
 		case 'activate':
 			if (!empty($user->rights->operationorder->status->write)) $object->setActive($user);
@@ -371,6 +371,22 @@ else
 			print '</div>';
 
 			print '</form>';
+
+			?>
+			<script>
+				let cb_req_planned_date = $('#require_planned_date');
+				let cb_clean_event = $('#clean_event');
+
+				cb_req_planned_date.on('click', function (){
+					if ($(this).prop('checked')) cb_clean_event.prop('checked', false)
+				})
+
+				cb_clean_event.on('click', function (){
+					if ($(this).prop('checked')) cb_req_planned_date.prop('checked', false)
+				})
+			</script>
+			<?php
+
 		}
 		elseif ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'create')))
 		{


### PR DESCRIPTION
FIX : 
- Ne peut pas passer au statut "Planifié" sans avoir saisi de date de planification => Un message d’erreur est envoyé 
- La création des eventOR se fait pour les ORs dont le statut courant possède le la configuration "display_on_planning" settée à 1
- Ne peut pas cocher les configuration "clean_event" et "require_planned_date" en même temps => Les champs se décoche lorsque l'on coche l'autre et inversement. 