### PR TITLE
FIX : Redimensionnement OR

### DIFF
--- a/scripts/interface.php
+++ b/scripts/interface.php
@@ -863,11 +863,11 @@ function _getTableDialogPlanable($startTime, $endTime, $allDay, $url, $id = 'cre
 function _updateOperationOrderAction($startTime, $endTime, $fk_action, $action,  $allDay){
     global $db, $user, $langs;
 
-	if (empty($user->rights->operationorder->counter->update))
-	{
-		setEventMessage($langs->trans('NotEnoughPermissions'), 'errors');
-		return false;
-	}
+//	if (empty($user->rights->operationorder->counter->update))
+//	{
+//		setEventMessage($langs->trans('NotEnoughPermissions'), 'errors');
+//		return false;
+//	}
 
     dol_include_once('/operationorder/class/operationorder.class.php');
     dol_include_once('/operationorder/class/operationorderaction.class.php');


### PR DESCRIPTION
### FIX : 

Le redimensionnement des ORs dans la vue planning était soumise au droit " _Pouvoir modifier les saisies de temps sur l'écran 'activités journalières'_ ". Ce droit n'étant pas lié à l'action de redimensionnement, je l'ai commenté. 