### PR TITLE
FIX TK12013 - Afficher le stock produit de l'entrepôt en question

### DIFF
--- a/class/operationorder.class.php
+++ b/class/operationorder.class.php
@@ -2083,7 +2083,13 @@ class OperationOrderDet extends SeedObject
             if(!empty($params['planned_date'])) $this->isVirtualStockAvailableForDate($params['planned_date']);
 
 
-            $tooltipLabel = $langs->trans('RealStock').' : '.$this->product->stock_reel.'</br>';
+            if(!empty($params['fk_warehouse'])) {
+                $stock_reel = $this->product->stock_warehouse[$params['fk_warehouse']]->real;
+            } else {
+                $stock_reel = $this->product->stock_reel;
+            }
+
+            $tooltipLabel = $langs->trans('RealStock').' : '.$stock_reel.'</br>';
 			$tooltipLabel.= $langs->trans('VirtualStock').' : '.$this->product->stock_theorique;
 
 			if(empty($params['attr']['title'])){
@@ -2091,13 +2097,13 @@ class OperationOrderDet extends SeedObject
 			}
 
 			if($this->product->stock_reel >= $this->qty){
-				$out .= dolGetBadge($langs->trans('StockAvailable').' '.$this->product->stock_reel, '','success classfortooltip', $mode, $url, $params);
+				$out .= dolGetBadge($langs->trans('StockAvailable').' '.$stock_reel, '','success classfortooltip', $mode, $url, $params);
 			}
 			elseif($this->product->stock_reel < $this->qty && $this->product->stock_theorique >= $this->qty){
-				$out .= dolGetBadge($langs->trans('VirtualStockAvailable').' '.$this->product->stock_reel, '', 'warning classfortooltip', $mode, $url, $params);
+				$out .= dolGetBadge($langs->trans('VirtualStockAvailable').' '.$stock_reel, '', 'warning classfortooltip', $mode, $url, $params);
 			}
 			else{
-				$out .= dolGetBadge($langs->trans('NotEnoughStockAvailable').' '.$this->product->stock_reel,'', 'danger classfortooltip', $mode, $url, $params);
+				$out .= dolGetBadge($langs->trans('NotEnoughStockAvailable').' '.$stock_reel,'', 'danger classfortooltip', $mode, $url, $params);
 			}
 		}
 

--- a/class/operationorder.class.php
+++ b/class/operationorder.class.php
@@ -2096,10 +2096,10 @@ class OperationOrderDet extends SeedObject
 				$params['attr']['title']=$tooltipLabel;
 			}
 
-			if($this->product->stock_reel >= $this->qty){
+			if($stock_reel >= $this->qty){
 				$out .= dolGetBadge($langs->trans('StockAvailable').' '.$stock_reel, '','success classfortooltip', $mode, $url, $params);
 			}
-			elseif($this->product->stock_reel < $this->qty && $this->product->stock_theorique >= $this->qty){
+			elseif($stock_reel < $this->qty && $this->product->stock_theorique >= $this->qty){
 				$out .= dolGetBadge($langs->trans('VirtualStockAvailable').' '.$stock_reel, '', 'warning classfortooltip', $mode, $url, $params);
 			}
 			else{

--- a/operationorder_card.php
+++ b/operationorder_card.php
@@ -1627,7 +1627,7 @@ function _displaySortableNestedItems($TNested, $htmlId='', $open = true, $planne
 
 			// STOCK
 			$out .= '		<div class="operation-order-sortable-list__item__title__col -stock-status">';
-			$out .= $line->stockStatus('', '', array('planned_date' => $planned_date));
+			$out .= $line->stockStatus('', '', array('planned_date' => $planned_date, 'fk_warehouse' => $line->fk_warehouse));
 
 			// display object linked on line
 			if (! isset($conf->operationorderdet->enabled))


### PR DESCRIPTION
Le stock produit réel affiché dans une ligne d'OR était le stock total de toutes les entités. Or, il faut afficher le stock de l'entrepôt de la ligne.

TK : https://support.atm-consulting.fr/view.php?id=12013